### PR TITLE
Syntax fix to display ASCII logo correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@
 
 ### ASCII Art
 
-```    __
+```
+    __
   []  []-o CHIPS
 o-[]  []
   []  []-o ALLIANCE


### PR DESCRIPTION
The top of the chip didn't display correctly